### PR TITLE
Mathemaphysics/issue2

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,11 +53,57 @@
         {
             "name": "agent-makefiles-configure-debug",
             "displayName": "POCO Unix Makefiles Configuration (Debug)",
-            "description": "Default build using Unix Makefiles generator",
+            "description": "Debug build using Unix Makefiles generator",
             "generator": "Unix Makefiles",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
+                "ENABLE_ACTIVERECORD": "FALSE",
+                "ENABLE_ACTIVERECORD_COMPILER": "FALSE",
+                "ENABLE_APACHECONNECTOR": "FALSE",
+                "ENABLE_CPPPARSER": "FALSE",
+                "ENABLE_CRYPTO": "FALSE",
+                "ENABLE_DATA": "FALSE",
+                "ENABLE_DATA_MYSQL": "FALSE",
+                "ENABLE_DATA_ODBC": "FALSE",
+                "ENABLE_DATA_POSTGRESQL": "FALSE",
+                "ENABLE_DATA_SQLITE": "FALSE",
+                "ENABLE_ENCODINGS": "FALSE",
+                "ENABLE_ENCODINGS_COMPILER": "FALSE",
+                "ENABLE_FOUNDATION": "TRUE",
+                "ENABLE_JSON": "FALSE",
+                "ENABLE_JWT": "FALSE",
+                "ENABLE_MONGODB": "FALSE",
+                "ENABLE_NET": "TRUE",
+                "ENABLE_NETSSL": "FALSE",
+                "ENABLE_NETSSL_WIN": "FALSE",
+                "ENABLE_PAGECOMPILER": "FALSE",
+                "ENABLE_PAGECOMPILER_FILE2PAGE": "FALSE",
+                "ENABLE_PDF": "FALSE",
+                "ENABLE_POCODOC": "FALSE",
+                "ENABLE_REDIS": "FALSE",
+                "ENABLE_SEVENZIP": "FALSE",
+                "ENABLE_TESTS": "FALSE",
+                "ENABLE_UTIL": "FALSE",
+                "ENABLE_XML": "FALSE",
+                "ENABLE_ZIP": "FALSE",
+                "JSONCPP_WITH_TESTS": "FALSE",
+                "JSONCPP_WITH_POST_BUILD_UNITTEST": "FALSE",
+                "JSONCPP_WITH_PKGCONFIG_SUPPORT": "FALSE",
+                "FETCHCONTENT_QUIET": "FALSE",
+                "GIT_PROGRESS": "TRUE",
+                "BUILD_TESTING": "TRUE"
+            }
+        },
+        {
+            "name": "agent-makefiles-configure-debug-cov",
+            "displayName": "POCO Unix Makefiles Configuration (Debug+Coverage)",
+            "description": "Debug+Coverage build using Unix Makefiles generator",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS": "--coverage -fprofile-arcs -ftest-coverage",
                 "ENABLE_ACTIVERECORD": "FALSE",
                 "ENABLE_ACTIVERECORD_COMPILER": "FALSE",
                 "ENABLE_APACHECONNECTOR": "FALSE",
@@ -106,6 +152,11 @@
             "name": "agent-makefiles-build-debug",
             "displayName": "POCO Unix Makefiles Build (Debug)",
             "configurePreset": "agent-makefiles-configure-debug"
+        },
+        {
+            "name": "agent-makefiles-build-debug-cov",
+            "displayName": "POCO Unix Makefiles Build (Debug+Coverage)",
+            "configurePreset": "agent-makefiles-configure-debug-cov"
         }
     ],
     "testPresets": [
@@ -125,6 +176,18 @@
             "name": "agent-makefiles-test-debug",
             "displayName": "POCO Unix Makefiles Test (Debug)",
             "configurePreset": "agent-makefiles-configure-debug",
+            "output": {
+                "outputOnFailure": true
+            },
+            "execution": {
+                "noTestsAction": "error",
+                "stopOnFailure": true
+            }
+        },
+        {
+            "name": "agent-makefiles-test-debug-cov",
+            "displayName": "POCO Unix Makefiles Test (Debug+Coverage)",
+            "configurePreset": "agent-makefiles-configure-debug-cov",
             "output": {
                 "outputOnFailure": true
             },

--- a/src/AMQPWorker.cpp
+++ b/src/AMQPWorker.cpp
@@ -4,7 +4,7 @@
 #include <amqpcpp.h>
 
 agent::AMQPWorker::AMQPWorker(
-    int _id,
+    unsigned int _id,
     std::string _host,
     std::uint16_t _port,
     std::string _name,

--- a/src/AMQPWorker.hpp
+++ b/src/AMQPWorker.hpp
@@ -26,7 +26,7 @@ namespace agent
 		 * @param _pass AMQP password
 		 */
 		AMQPWorker(
-			int _id,
+			unsigned int _id,
 			std::string _host,
 			std::uint16_t _port,
 			std::string _name,

--- a/src/Worker.cpp
+++ b/src/Worker.cpp
@@ -13,32 +13,16 @@
 agent::Worker::Worker(unsigned int _id)
     : IWorker(_id)
 {
-    // Check if logger called GetName() exists, else create it
-    _logger = spdlog::get(GetName());
-    if (_logger == nullptr)
-        _logger = spdlog::stdout_color_mt(GetName());
 }
 
 agent::Worker::Worker(unsigned int _id, std::string _name)
     : IWorker(_id, _name)
 {
-    _logger = spdlog::get(GetName());
-    if (_logger == nullptr)
-        _logger = spdlog::stdout_color_mt(GetName());
 }
 
 agent::Worker::~Worker()
 {
     _logger->info("Worker {} finished", GetId());
-}
-
-std::string agent::Worker::ThreadToString(std::thread::id _tid)
-{
-    auto ssThread = std::ostringstream();
-
-    ssThread << _tid;
-
-    return ssThread.str();
 }
 
 int agent::Worker::ProcessMessage(const void* _msg, flatbuffers::uoffset_t _size) const
@@ -54,43 +38,4 @@ int agent::Worker::ProcessMessage(const void* _msg, flatbuffers::uoffset_t _size
         id, width, height);
 
     return id;
-}
-
-void agent::Worker::operator()()
-{
-    while (GetState() != WORKER_QUIT)
-    {
-        // Create space for a potential message
-        bool received = false;
-        std::pair<void *, flatbuffers::uoffset_t> curmsg;
-
-        // Lock _data and grab a message
-        _data_lock.lock();
-        if (!_data.empty())
-        {
-            curmsg = _data.back();
-            _data.pop_back();
-            received = true;
-        }
-        _data_lock.unlock();
-
-        // Now the lock is off; process the message
-        if (received)
-        {
-            // Now process it
-            const auto message = curmsg.first;
-            const auto size = curmsg.second;
-            try
-            {
-                int msgId = ProcessMessage(message, size);
-                _logger->info("[{}] Successfully processed message {}",
-                    ThreadToString(std::this_thread::get_id()),
-                    msgId);
-            }
-            catch(const std::exception& e)
-            {
-                _logger->critical(e.what());
-            }
-        }
-    }
 }

--- a/src/Worker.hpp
+++ b/src/Worker.hpp
@@ -41,14 +41,6 @@ namespace agent
 		~Worker();
 
 		/**
-		 * @brief Converts a \c std::thread::id to \c std::string
-		 * 
-		 * @param _tid Thread ID
-		 * @return std::string Converted string
-		 */
-		static std::string ThreadToString(std::thread::id _tid);
-
-		/**
 		 * @brief The function which does the work on each message
 		 * 
 		 * This is the function which does the job of the \c Worker.
@@ -60,9 +52,5 @@ namespace agent
 		 * @return int ID of the message it processed
 		 */
 		int ProcessMessage(const void* _msg, flatbuffers::uoffset_t _size) const override;
-		void operator()() override;
-
-	protected:
-		std::shared_ptr<spdlog::logger> _logger = nullptr;
 	};
 }


### PR DESCRIPTION
Moved the `operator()` loop into `IWorker` successfully. Removed the need for user to define both `ProcessMessage` and `operator()` which is required to *use* `ProcessMessage`.