### PR TITLE
Mathemaphysics/issue22

### DIFF
--- a/src/IAMQPWorker.hpp
+++ b/src/IAMQPWorker.hpp
@@ -115,6 +115,19 @@ namespace agent
 		}
 
 		/**
+		 * @brief Overridden version of \c AddMessage from \c IWorker which,
+		 * instead of adding to the local \c std::deque of message, adds the
+		 * message to the AMQP queue
+		 * 
+		 * @param _msg  Pointer to the message itself
+		 * @param _size Size of the message (in bytes)
+		 */
+		void AddMessage(const void* _msg, std::uint32_t _size, std::string _exchange = "", std::string _key = "")
+		{
+			_channel.publish(_exchange, _key, (char*)_msg, _size, 0);
+		}
+
+		/**
 		 * @brief Worker that runs a single message
 		 * 
 		 * The worker can be run with any number of threads, the idea being that

--- a/src/IAMQPWorker.hpp
+++ b/src/IAMQPWorker.hpp
@@ -124,7 +124,7 @@ namespace agent
 		 */
 		void AddMessage(const void* _msg, std::uint32_t _size, std::string _exchange = "", std::string _key = "")
 		{
-			_channel.publish(_exchange, _key, (char*)_msg, _size, 0);
+			_channel.publish(_exchange, _key, static_cast<const char*>(_msg), _size, 0);
 		}
 
 		/**

--- a/src/IWorker.hpp
+++ b/src/IWorker.hpp
@@ -180,7 +180,7 @@ namespace agent
 			_state.store(WORKER_QUIT);
 		}
 
-		void AddMessage(const void* _msg, std::uint32_t _size)
+		virtual void AddMessage(const void* _msg, std::uint32_t _size)
 		{
 			_data_lock.lock();
 			_data.push_front(std::pair<const void*, std::uint32_t>(_msg, _size));


### PR DESCRIPTION
Instead of creating `AddMessage` in `IConnectionHandler` created it in `IAMQPWorker` because publishing to an exchange requires an `AMQP::Channel`, which doesn't exist in `IConnectionHandler`.