### PR TITLE
Fixed CPU pinning due to main loop without a sleep; removed problematic git feature from devcontainer.json and updated Dockerfile to point to specific cmake-base image tag 3.22 instead of just "latest" which didn't exist.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mathemaphysics/cmake-base:latest
+FROM mathemaphysics/cmake-base:3.22
 
 ARG DEVUSER devuser
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,10 +59,7 @@
 	// "postCreateCommand": "gcc -v",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "devuser",
-	"features": {
-		"git": "os-provided"
-	}
+	"remoteUser": "devuser"
 
 	//// Maps the .ssh/ folder from your ${HOME} into /home/devuser/.ssh
 	//"mounts": [

--- a/src/FWorker.cpp
+++ b/src/FWorker.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <atomic>
 #include <thread>
+#include <chrono>
 #include <mutex>
 #include <vector>
 #include <deque>
@@ -162,5 +163,8 @@ void agent::FWorker::operator()()
                 _logger->critical(e.what());
             }
         }
+
+        // TODO: Make this delay configurable via JSON sometime
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 }

--- a/src/IWorker.cpp
+++ b/src/IWorker.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <atomic>
 #include <thread>
+#include <chrono>
 #include <mutex>
 #include <vector>
 #include <deque>
@@ -157,5 +158,8 @@ void agent::IWorker::operator()()
                 _logger->critical(e.what());
             }
         }
+
+        // TODO: Make this delay configurable via JSON sometime
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 }


### PR DESCRIPTION
CPU is no longer hard pinned due to lack of a loop sleep in the base IWorker class.